### PR TITLE
Add preinstall script to fix yarn workspaces issue on windows

### DIFF
--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -11,6 +11,7 @@
 	},
 	"main": "__generated__/AppEntry.js",
 	"scripts": {
+		"preinstall": "node ./patch-yarn.js",
 		"postinstall": "expo-yarn-workspaces postinstall",
 		"start": "expo start",
 		"ios": "expo start --ios",

--- a/packages/app/patch-yarn.js
+++ b/packages/app/patch-yarn.js
@@ -1,0 +1,32 @@
+// Yarn has (v1.17.3) still a path lookup bug on Windows, when it looks for the binaries referenced in
+// scripts under '\gui\node_modules\node_modules' instead of '\gui\node_modules'.
+// This patch adds a junction between those two to keep that house of cards from falling apart.
+// GitHub issue: https://github.com/yarnpkg/yarn/issues/4564#issuecomment-414613939,
+// Pull Request: https://github.com/mullvad/mullvadvpn-app/pull/369
+
+const path = require('path');
+const fs = require('fs');
+
+if (process.platform !== 'win32') {
+  return;
+}
+
+const sourcePath = path.resolve(path.join(__dirname, '../../node_modules'));
+const symlinkPath = path.join(__dirname, '../../node_modules/node_modules');
+
+try {
+  console.log('Removing a symlink to node_modules/node_modules');
+  fs.unlinkSync(symlinkPath);
+} catch (error) {
+  if (error.code !== 'ENOENT') {
+    throw error;
+  }
+}
+
+try {
+  console.log('Applying yarn workspaces patch for node_modules/node_modules');
+  fs.symlinkSync(sourcePath, symlinkPath, 'junction');
+  console.log('Done');
+} catch (error) {
+  console.error('Cannot symlink node_modules/node_modules: ' + error.message);
+}


### PR DESCRIPTION
https://github.com/yarnpkg/yarn/issues/4564

## Description

Add preinstall script to fix yarn workspaces issue on windows

## Steps to reproduce

On windows try installing dependencies (yarn) in project root

In app package, you will see following error.
Cannot find module **'...Auxilium\node_modules\node_modules\expo-yarn-workspaces\bin\expo-yarn-workspaces.js'**

## Impacted Areas

- [x] Mobile App
